### PR TITLE
Multi-Lang on a single domain

### DIFF
--- a/app/coffee/translations.coffee
+++ b/app/coffee/translations.coffee
@@ -14,10 +14,15 @@ module.exports =
 			sendMissingTo: "fallback"
 			fallbackLng: options?.defaultLng || "en"
 			detectLngFromHeaders: true
+			detectLanguageFn: (req, res) ->
+				return req.session.lng
 			useCookie: false
 			preload: availableLngs
 			supportedLngs: availableLngs
 		setLangBasedOnDomainMiddlewear = (req, res, next) ->
+			if req.query.setGlobalLng
+				req.session.lng = subdomainLang[req.query.setGlobalLng]?.lngCode
+				return res.redirect req.path
 
 			host = req.headers.host
 			if !host?

--- a/app/js/translations.js
+++ b/app/js/translations.js
@@ -1,9 +1,11 @@
 (function() {
-  var i18n, _;
+  var i18n, path, _;
 
   i18n = require("i18next");
 
   _ = require("underscore");
+
+  path = require("path");
 
   module.exports = {
     setup: function(options) {
@@ -11,9 +13,9 @@
       subdomainLang = (options != null ? options.subdomainLang : void 0) || {};
       availableLngs = _.pluck(_.values(subdomainLang), "lngCode");
       i18n.init({
-        resGetPath: __dirname + "/locales/__lng__.json",
+        resGetPath: path.resolve(__dirname, "../../", "locales/__lng__.json"),
         saveMissing: true,
-        resSetPath: __dirname + "/locales/missing-__lng__.json",
+        resSetPath: path.resolve(__dirname, "../../", "locales/missing-__lng__.json"),
         sendMissingTo: "fallback",
         fallbackLng: (options != null ? options.defaultLng : void 0) || "en",
         detectLngFromHeaders: true,
@@ -22,15 +24,13 @@
         supportedLngs: availableLngs
       });
       setLangBasedOnDomainMiddlewear = function(req, res, next) {
-        var host, lang, subdomain, _ref, _ref1;
+        var host, lang, parts, subdomain, _ref, _ref1;
         host = req.headers.host;
         if (host == null) {
           return next();
         }
-        subdomain = host.slice(0, host.indexOf("."));
-        if (subdomain == null) {
-          return next();
-        }
+        parts = host.split(/[.-]/);
+        subdomain = parts[0];
         lang = options != null ? (_ref = options.subdomainLang) != null ? (_ref1 = _ref[subdomain]) != null ? _ref1.lngCode : void 0 : void 0 : void 0;
         if (req.originalUrl.indexOf("setLng") === -1 && (lang != null)) {
           req.i18n.setLng(lang);

--- a/app/js/translations.js
+++ b/app/js/translations.js
@@ -19,19 +19,26 @@
         sendMissingTo: "fallback",
         fallbackLng: (options != null ? options.defaultLng : void 0) || "en",
         detectLngFromHeaders: true,
+        detectLanguageFn: function(req, res) {
+          return req.session.lng;
+        },
         useCookie: false,
         preload: availableLngs,
         supportedLngs: availableLngs
       });
       setLangBasedOnDomainMiddlewear = function(req, res, next) {
-        var host, lang, parts, subdomain, _ref, _ref1;
+        var host, lang, parts, subdomain, _ref, _ref1, _ref2;
+        if (req.query.setGlobalLng) {
+          req.session.lng = (_ref = subdomainLang[req.query.setGlobalLng]) != null ? _ref.lngCode : void 0;
+          return res.redirect(req.path);
+        }
         host = req.headers.host;
         if (host == null) {
           return next();
         }
         parts = host.split(/[.-]/);
         subdomain = parts[0];
-        lang = options != null ? (_ref = options.subdomainLang) != null ? (_ref1 = _ref[subdomain]) != null ? _ref1.lngCode : void 0 : void 0 : void 0;
+        lang = options != null ? (_ref1 = options.subdomainLang) != null ? (_ref2 = _ref1[subdomain]) != null ? _ref2.lngCode : void 0 : void 0 : void 0;
         if (req.originalUrl.indexOf("setLng") === -1 && (lang != null)) {
           req.i18n.setLng(lang);
         }

--- a/test/unit/coffee/translations-tests.coffee
+++ b/test/unit/coffee/translations-tests.coffee
@@ -25,8 +25,24 @@ describe "translations", ->
 			originalUrl:"doesn'tmatter.sharelatex.com/login"
 			headers:
 				"accept-language":""
-		@res = {}
+			query: {}
+			session: {}
+		@res =
+			redirect: sinon.stub()
 
+	describe "handle", ->
+		beforeEach (done) ->
+			@req.path = '/login'
+			@req.query.setGlobalLng = "da"
+			@translations.expressMiddlewear @req, @res, =>
+				@translations.setLangBasedOnDomainMiddlewear @req, @res
+				done()
+
+		it "should send the user back", ->
+			@res.redirect.calledWith('/login').should.equal true
+
+		it "should set the requested lang permanent", ->
+			@req.session.lng.should.equal "da"
 
 	describe "setLangBasedOnDomainMiddlewear", ->
 

--- a/test/unit/coffee/translations-tests.coffee
+++ b/test/unit/coffee/translations-tests.coffee
@@ -33,7 +33,7 @@ describe "translations", ->
 		it "should set the lang to french if the domain is fr", (done)->
 			@req.url = "fr.sharelatex.com/login"
 			@req.headers.host = "fr.sharelatex.com"
-			@translations.expressMiddlewear @req, @req, =>
+			@translations.expressMiddlewear @req, @res, =>
 				@translations.setLangBasedOnDomainMiddlewear @req, @res, =>
 					@req.lng.should.equal "fr"
 					done()
@@ -45,7 +45,7 @@ describe "translations", ->
 				@req.headers["accept-language"] = "da, en-gb;q=0.8, en;q=0.7"
 				@req.url = "fr.sharelatex.com/login"
 				@req.headers.host = "fr.sharelatex.com"
-				@translations.expressMiddlewear @req, @req, =>
+				@translations.expressMiddlewear @req, @res, =>
 					@translations.setLangBasedOnDomainMiddlewear @req, @res, =>
 						@req.showUserOtherLng.should.equal "da"
 						done()
@@ -55,7 +55,7 @@ describe "translations", ->
 				@req.headers["accept-language"] = "da, en-gb;q=0.8, en;q=0.7"
 				@req.url = "da.sharelatex.com/login"
 				@req.headers.host = "da.sharelatex.com"
-				@translations.expressMiddlewear @req, @req, =>
+				@translations.expressMiddlewear @req, @res, =>
 					@translations.setLangBasedOnDomainMiddlewear @req, @res, =>
 						expect(@req.showUserOtherLng).to.not.exist
 						done()

--- a/test/unit/js/translations-tests.js
+++ b/test/unit/js/translations-tests.js
@@ -48,9 +48,31 @@
         originalUrl: "doesn'tmatter.sharelatex.com/login",
         headers: {
           "accept-language": ""
-        }
+        },
+        query: {},
+        session: {}
       };
-      return this.res = {};
+      return this.res = {
+        redirect: sinon.stub()
+      };
+    });
+    describe("handle", function() {
+      beforeEach(function(done) {
+        this.req.path = '/login';
+        this.req.query.setGlobalLng = "da";
+        return this.translations.expressMiddlewear(this.req, this.res, (function(_this) {
+          return function() {
+            _this.translations.setLangBasedOnDomainMiddlewear(_this.req, _this.res);
+            return done();
+          };
+        })(this));
+      });
+      it("should send the user back", function() {
+        return this.res.redirect.calledWith('/login').should.equal(true);
+      });
+      return it("should set the requested lang permanent", function() {
+        return this.req.session.lng.should.equal("da");
+      });
     });
     return describe("setLangBasedOnDomainMiddlewear", function() {
       it("should set the lang to french if the domain is fr", function(done) {

--- a/test/unit/js/translations-tests.js
+++ b/test/unit/js/translations-tests.js
@@ -56,7 +56,7 @@
       it("should set the lang to french if the domain is fr", function(done) {
         this.req.url = "fr.sharelatex.com/login";
         this.req.headers.host = "fr.sharelatex.com";
-        return this.translations.expressMiddlewear(this.req, this.req, (function(_this) {
+        return this.translations.expressMiddlewear(this.req, this.res, (function(_this) {
           return function() {
             return _this.translations.setLangBasedOnDomainMiddlewear(_this.req, _this.res, function() {
               _this.req.lng.should.equal("fr");
@@ -70,7 +70,7 @@
           this.req.headers["accept-language"] = "da, en-gb;q=0.8, en;q=0.7";
           this.req.url = "fr.sharelatex.com/login";
           this.req.headers.host = "fr.sharelatex.com";
-          return this.translations.expressMiddlewear(this.req, this.req, (function(_this) {
+          return this.translations.expressMiddlewear(this.req, this.res, (function(_this) {
             return function() {
               return _this.translations.setLangBasedOnDomainMiddlewear(_this.req, _this.res, function() {
                 _this.req.showUserOtherLng.should.equal("da");
@@ -83,7 +83,7 @@
           this.req.headers["accept-language"] = "da, en-gb;q=0.8, en;q=0.7";
           this.req.url = "da.sharelatex.com/login";
           this.req.headers.host = "da.sharelatex.com";
-          return this.translations.expressMiddlewear(this.req, this.req, (function(_this) {
+          return this.translations.expressMiddlewear(this.req, this.res, (function(_this) {
             return function() {
               return _this.translations.setLangBasedOnDomainMiddlewear(_this.req, _this.res, function() {
                 expect(_this.req.showUserOtherLng).to.not.exist;


### PR DESCRIPTION
This PR adds support for multiple languages on a single domain - or even a bare IP address.

It introduces a query parameter `setGlobalLng` to set a new language.
E.g. `https://example.com/login?setGlobalLng=de` to select the German translation.
The language is then stored in the user session.

Using subdomains/request-header for the language setting continues to work as before.

A patch for the web service is shown in https://github.com/das7pad/web-sharelatex/commit/844fdbe1d532ddae101c08d6d46893dfb1a92f7f and I can submit a rebased/decaffeinated PR once this is merged.

_You can play with the language selection on https://sharelatex.das7pad.de_