### PR TITLE
[misc] cleanup dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -251,12 +251,14 @@
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
       "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
+      "dev": true,
       "optional": true
     },
     "assert-plus": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
       "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
+      "dev": true,
       "optional": true
     },
     "assertion-error": {
@@ -271,18 +273,11 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
-    "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "requires": {
-        "lodash": "^4.17.14"
-      }
-    },
     "aws-sign2": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
       "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
+      "dev": true,
       "optional": true
     },
     "balanced-match": {
@@ -307,6 +302,7 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
       "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
+      "dev": true,
       "optional": true,
       "requires": {
         "hoek": "0.9.x"
@@ -336,16 +332,6 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
-    },
-    "bunyan": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-0.22.1.tgz",
-      "integrity": "sha1-Agw4O+1iWvXGyINN2MSsoN0Pdlw=",
-      "dev": true,
-      "requires": {
-        "dtrace-provider": "0.2.8",
-        "mv": "0.0.5"
-      }
     },
     "callsites": {
       "version": "3.1.0",
@@ -495,6 +481,7 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
       "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
+      "dev": true,
       "optional": true,
       "requires": {
         "delayed-stream": "0.0.5"
@@ -558,6 +545,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
       "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
+      "dev": true,
       "optional": true,
       "requires": {
         "boom": "0.4.x"
@@ -567,6 +555,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
       "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
+      "dev": true,
       "optional": true
     },
     "debug": {
@@ -620,6 +609,7 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
       "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
+      "dev": true,
       "optional": true
     },
     "depd": {
@@ -679,13 +669,6 @@
         "domelementtype": "^2.0.1",
         "domhandler": "^3.0.0"
       }
-    },
-    "dtrace-provider": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz",
-      "integrity": "sha1-4kPxkhmqlfvw2PL/sH9b1k6U/iA=",
-      "dev": true,
-      "optional": true
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -1274,12 +1257,14 @@
     "forever-agent": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
-      "integrity": "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA="
+      "integrity": "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA=",
+      "dev": true
     },
     "form-data": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
       "integrity": "sha1-kavXiKupcCsaq/qLwBAxoqyeOxI=",
+      "dev": true,
       "optional": true,
       "requires": {
         "async": "~0.9.0",
@@ -1291,6 +1276,7 @@
           "version": "0.9.2",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+          "dev": true,
           "optional": true
         }
       }
@@ -1370,23 +1356,6 @@
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
-    "grunt-bunyan": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/grunt-bunyan/-/grunt-bunyan-0.5.0.tgz",
-      "integrity": "sha1-aCnXbgGZQ9owQTk2MaNuKsgpsWw=",
-      "dev": true,
-      "requires": {
-        "lodash": "~2.4.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        }
-      }
-    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -1428,6 +1397,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
       "integrity": "sha1-h81JH5tG5OKurKM1QWdmiF0tHtk=",
+      "dev": true,
       "optional": true,
       "requires": {
         "boom": "0.4.x",
@@ -1446,6 +1416,7 @@
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
       "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
+      "dev": true,
       "optional": true
     },
     "hosted-git-info": {
@@ -1469,6 +1440,7 @@
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
       "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
+      "dev": true,
       "optional": true,
       "requires": {
         "asn1": "0.1.11",
@@ -1630,6 +1602,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
       "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+      "dev": true,
       "optional": true
     },
     "is-arrayish": {
@@ -1765,7 +1738,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json5": {
       "version": "0.2.0",
@@ -1829,7 +1803,8 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -1998,12 +1973,14 @@
       "version": "1.2.11",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
       "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA=",
+      "dev": true,
       "optional": true
     },
     "mime-types": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
-      "integrity": "sha1-mVrhOSq4r/y/yyZB3QVOlDwNXc4="
+      "integrity": "sha1-mVrhOSq4r/y/yyZB3QVOlDwNXc4=",
+      "dev": true
     },
     "mimic-fn": {
       "version": "2.1.0",
@@ -2154,13 +2131,6 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
-    "mv": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/mv/-/mv-0.0.5.tgz",
-      "integrity": "sha1-FerHWUeYhN8RMdbeVrziC2VPU5E=",
-      "dev": true,
-      "optional": true
-    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -2207,7 +2177,8 @@
     "node-uuid": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
+      "dev": true
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -2239,6 +2210,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz",
       "integrity": "sha1-y1QPk7srIqfVlBaRoojWDo6pOG4=",
+      "dev": true,
       "optional": true
     },
     "object-inspect": {
@@ -2300,6 +2272,7 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/onesky/-/onesky-0.1.6.tgz",
       "integrity": "sha1-fw1oy4DN/51ETHzVURZdgow0zaw=",
+      "dev": true,
       "requires": {
         "request": "~2.40.0",
         "underscore": "~1.6.0"
@@ -2308,7 +2281,8 @@
         "underscore": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+          "dev": true
         }
       }
     },
@@ -3138,17 +3112,20 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
       "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ==",
+      "dev": true,
       "optional": true
     },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "qs": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-1.0.2.tgz",
-      "integrity": "sha1-UKk+K1r2aRwxvOpdrnjubqGQN2g="
+      "integrity": "sha1-UKk+K1r2aRwxvOpdrnjubqGQN2g=",
+      "dev": true
     },
     "quick-lru": {
       "version": "4.0.1",
@@ -3202,6 +3179,7 @@
       "version": "2.40.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.40.0.tgz",
       "integrity": "sha1-TdZw9pbx5uhC5mtLXoOTAaub62c=",
+      "dev": true,
       "requires": {
         "aws-sign2": "~0.5.0",
         "forever-agent": "~0.5.0",
@@ -3412,6 +3390,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
       "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
+      "dev": true,
       "optional": true,
       "requires": {
         "hoek": "0.9.x"
@@ -3517,6 +3496,7 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
       "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
+      "dev": true,
       "optional": true
     },
     "strip-bom": {
@@ -3625,6 +3605,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
       "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+      "dev": true,
       "optional": true,
       "requires": {
         "ip-regex": "^2.1.0",
@@ -3647,6 +3628,7 @@
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
       "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+      "dev": true,
       "optional": true
     },
     "type-check": {

--- a/package.json
+++ b/package.json
@@ -13,14 +13,11 @@
     "test": "mocha $@ test/unit/js"
   },
   "dependencies": {
-    "async": "^2.1.4",
     "i18next": "^1.10.6",
-    "onesky": "~0.1.5",
     "sanitize-html": "^1.14.1",
     "underscore": "^1.6.0"
   },
   "devDependencies": {
-    "bunyan": "0.22.1",
     "chai": "~1.8.1",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.0",
@@ -33,8 +30,8 @@
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
-    "grunt-bunyan": "0.5.0",
     "mocha": "^7.1.0",
+    "onesky": "~0.1.5",
     "prettier-eslint-cli": "^5.0.0",
     "sandboxed-module": "0.2.0",
     "sinon": "~9.0.1"


### PR DESCRIPTION
`sanitize-html` and `onesky` are used by the download script only, `async` and `bunyan` are not used at all.

`sanitize-html` is used in web without a proper dependency on it, so I opted to keep it for now.

See https://github.com/das7pad/web-sharelatex/commit/844fdbe1d532ddae101c08d6d46893dfb1a92f7f#diff-36018a6a9e1de1798516799b84841318 for the diff of the package-lock.


The CI job is using `npm install` and will pick up the devDependencies as well.
https://github.com/overleaf/google-ops/blob/8cc95109b75406dcd21e608d89974badde61fb84/ops/ci/translations.jinja#L43-L47