### PR TITLE
[misc] fix decaff cleanup

### DIFF
--- a/download.js
+++ b/download.js
@@ -11,7 +11,7 @@ const sanitizeOpts = {
     a: ['href', 'class']
   },
   textFilter(text) {
-    text.replace(/\{\{/, '&#123;&#123;').replace(/\}\}/, '&#125;&#125;')
+    return text.replace(/\{\{/, '&#123;&#123;').replace(/\}\}/, '&#125;&#125;')
   }
 }
 


### PR DESCRIPTION
I noticed this while rebasing my fork.

<details>
<summary> before </summary>

<pre>
> const sanitizeHtml = require('sanitize-html')
undefined
> const sanitizeOpts = {
...   allowedTags: ['b', 'strong', 'a', 'code'],
...   allowedAttributes: {
.....     a: ['href', 'class']
.....   },
...   textFilter(text) {
.....     text.replace(/\{\{/, '&#123;&#123;').replace(/\}\}/, '&#125;&#125;')
.....   }
... }
undefined
> sanitizeHtml('localized string', sanitizeOpts)
'undefined'
>
</pre>
</details>


<details>
<summary> after </summary>

<pre>
> const sanitizeHtml = require('sanitize-html')
undefined
> const sanitizeOpts = {
...   allowedTags: ['b', 'strong', 'a', 'code'],
...   allowedAttributes: {
.....     a: ['href', 'class']
.....   },
...   textFilter(text) {
.....     return text.replace(/\{\{/, '&#123;&#123;').replace(/\}\}/, '&#125;&#125;')
.....   }
... }
undefined
> sanitizeHtml('localized string', sanitizeOpts)
'localized string'
</pre>
</details>




REF: 87980056c4ad1f1fd07f2ed8977caf1e4e69e658