### PR TITLE
Read secrets from ENV rather than args

### DIFF
--- a/download.js
+++ b/download.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
-const publicKey = process.argv[2]
-const privateKey = process.argv[3]
+const publicKey = process.env.ONE_SKY_PUBLIC_KEY
+const privateKey = process.env.ONE_SKY_PRIVATE_KEY
 const _ = require('underscore')
 
 const onesky = require('onesky')(publicKey, privateKey)


### PR DESCRIPTION
Read the secrets from environment variables rather than the command line. Improves consistency with how other scripts work (e.g. https://github.com/overleaf/mongo-backups-verifier/blob/master/atlas_backup_downloader.js ) and simplifies integration with Cloud Build where secrets are decrypted into environment variables.

(Without this we have to override the entrypoint with a shell so that the enironment variables are evaluated.)