### PR TITLE
Helper script to push processed translations back to git

### DIFF
--- a/push-changes.sh
+++ b/push-changes.sh
@@ -1,0 +1,9 @@
+set -e
+
+if [[ `git status --porcelain` ]]; then
+  git add locales/*
+  git commit -m "auto update translation"
+  git push origin HEAD:master
+else
+  echo 'No changes'
+fi


### PR DESCRIPTION
Refactoring the Cloud Build Translations job to bring it into line with the other Cloud Build jobs.

I don't know how to embed multi line scripts into a jinja template of a cloudbuild.yaml, so adding the script to this repo.