### PR TITLE
Specify upstream repo via environment variable

### DIFF
--- a/push-changes.sh
+++ b/push-changes.sh
@@ -4,7 +4,7 @@ set -e
 if [[ `git status --porcelain` ]]; then
   git add locales/*
   git commit -m "auto update translation"
-  git push origin HEAD:master
+  git push $UPSTREAM_REPO HEAD:master
 else
   echo 'No changes'
 fi


### PR DESCRIPTION
Allow the target for the push to be specified by environment variable.