### PR TITLE
Replace deprecated OneSky package

### DIFF
--- a/download.js
+++ b/download.js
@@ -1,8 +1,5 @@
 const fs = require('fs')
-const publicKey = process.env.ONE_SKY_PUBLIC_KEY
-const privateKey = process.env.ONE_SKY_PRIVATE_KEY
-
-const onesky = require('onesky')(publicKey, privateKey)
+const oneSky = require('@brainly/onesky-utils')
 const sanitizeHtml = require('sanitize-html')
 const sanitizeOpts = {
   allowedTags: ['b', 'strong', 'a', 'code'],
@@ -14,27 +11,38 @@ const sanitizeOpts = {
   }
 }
 
-onesky.string.output({ platformId: '25049' }, function(err, r) {
-  if (err) {
-    console.error(err)
-    return
-  }
+async function download() {
+  try {
+    const content = await oneSky.getMultilingualFile({
+      apiKey: process.env.ONE_SKY_PUBLIC_KEY,
+      secret: process.env.ONE_SKY_PRIVATE_KEY,
+      projectId: '25049',
+      fileName: 'en-US.json'
+    })
+    const json = JSON.parse(content)
 
-  for (const [code, lang] of Object.entries(r.translation['en-US.json'])) {
-    for (const [key, value] of Object.entries(lang)) {
-      lang[key] = sanitizeHtml(value, sanitizeOpts)
+    for (const [code, lang] of Object.entries(json)) {
+      for (const [key, value] of Object.entries(lang.translation)) {
+        lang.translation[key] = sanitizeHtml(value, sanitizeOpts)
+      }
+      fs.writeFileSync(
+        `./locales/${code}.json`,
+        JSON.stringify(lang.translation, null, 2)
+      )
     }
 
-    fs.writeFileSync(`./locales/${code}.json`, JSON.stringify(lang, null, 2))
+    fs.createReadStream('./locales/en-GB.json').pipe(
+      fs.createWriteStream('./locales/en-US.json')
+    )
+    fs.createReadStream('./locales/en-GB.json').pipe(
+      fs.createWriteStream('./locales/en.json')
+    )
+    fs.createReadStream('./locales/zh-CN.json').pipe(
+      fs.createWriteStream('./locales/cn.json')
+    )
+  } catch (error) {
+    console.error(error)
   }
+}
 
-  fs.createReadStream('./locales/en-GB.json').pipe(
-    fs.createWriteStream('./locales/en-US.json')
-  )
-  fs.createReadStream('./locales/en-GB.json').pipe(
-    fs.createWriteStream('./locales/en.json')
-  )
-  return fs
-    .createReadStream('./locales/zh-CN.json')
-    .pipe(fs.createWriteStream('./locales/cn.json'))
-})
+download()

--- a/download.js
+++ b/download.js
@@ -4,6 +4,12 @@ const sanitizeHtml = require('sanitize-html')
 
 async function run() {
   try {
+    // The recommended OneSky set-up appears to require an API request to
+    // generate files on their side, which you could then request and use. We
+    // only have 1 such file that appears to be misnamed (en-US, despite our
+    // translations being marked as GB) and very out-of-date.
+    // However by requesting the "multilingual file" for this file, we get all
+    // of the translations
     const content = await oneSky.getMultilingualFile({
       apiKey: process.env.ONE_SKY_PUBLIC_KEY,
       secret: process.env.ONE_SKY_PRIVATE_KEY,

--- a/download.js
+++ b/download.js
@@ -2,7 +2,7 @@ const { promises: fs } = require('fs')
 const oneSky = require('@brainly/onesky-utils')
 const sanitizeHtml = require('sanitize-html')
 
-async function download() {
+async function run() {
   try {
     const content = await oneSky.getMultilingualFile({
       apiKey: process.env.ONE_SKY_PUBLIC_KEY,
@@ -35,8 +35,7 @@ async function download() {
     console.error(error)
   }
 }
-
-download()
+run()
 
 function sanitize(input) {
   return sanitizeHtml(input, {

--- a/download.js
+++ b/download.js
@@ -39,6 +39,7 @@ async function run() {
     await fs.copyFile('./locales/zh-CN.json', './locales/cn.json')
   } catch (error) {
     console.error(error)
+    process.exit(1)
   }
 }
 run()

--- a/download.js
+++ b/download.js
@@ -23,7 +23,11 @@ async function download() {
     const json = JSON.parse(content)
 
     for (const [code, lang] of Object.entries(json)) {
-      for (const [key, value] of Object.entries(lang.translation)) {
+      for (let [key, value] of Object.entries(lang.translation)) {
+        // Handle multi-line strings as arrays by joining on newline
+        if (Array.isArray(value)) {
+          value = value.join('\n')
+        }
         lang.translation[key] = sanitizeHtml(value, sanitizeOpts)
       }
 

--- a/download.js
+++ b/download.js
@@ -1,5 +1,6 @@
-const fs = require('fs')
+const { promises: fs } = require('fs')
 const oneSky = require('@brainly/onesky-utils')
+
 const sanitizeHtml = require('sanitize-html')
 const sanitizeOpts = {
   allowedTags: ['b', 'strong', 'a', 'code'],
@@ -25,21 +26,17 @@ async function download() {
       for (const [key, value] of Object.entries(lang.translation)) {
         lang.translation[key] = sanitizeHtml(value, sanitizeOpts)
       }
-      fs.writeFileSync(
+
+      await fs.writeFile(
         `./locales/${code}.json`,
         JSON.stringify(lang.translation, null, 2)
       )
     }
 
-    fs.createReadStream('./locales/en-GB.json').pipe(
-      fs.createWriteStream('./locales/en-US.json')
-    )
-    fs.createReadStream('./locales/en-GB.json').pipe(
-      fs.createWriteStream('./locales/en.json')
-    )
-    fs.createReadStream('./locales/zh-CN.json').pipe(
-      fs.createWriteStream('./locales/cn.json')
-    )
+    // Copy files, so we have appropriate dialects
+    await fs.copyFile('./locales/en-GB.json', './locales/en-US.json')
+    await fs.copyFile('./locales/en-GB.json', './locales/en.json')
+    await fs.copyFile('./locales/zh-CN.json', './locales/cn.json')
   } catch (error) {
     console.error(error)
   }

--- a/download.js
+++ b/download.js
@@ -1,16 +1,6 @@
 const { promises: fs } = require('fs')
 const oneSky = require('@brainly/onesky-utils')
-
 const sanitizeHtml = require('sanitize-html')
-const sanitizeOpts = {
-  allowedTags: ['b', 'strong', 'a', 'code'],
-  allowedAttributes: {
-    a: ['href', 'class']
-  },
-  textFilter(text) {
-    return text.replace(/\{\{/, '&#123;&#123;').replace(/\}\}/, '&#125;&#125;')
-  }
-}
 
 async function download() {
   try {
@@ -28,7 +18,7 @@ async function download() {
         if (Array.isArray(value)) {
           value = value.join('\n')
         }
-        lang.translation[key] = sanitizeHtml(value, sanitizeOpts)
+        lang.translation[key] = sanitize(value)
       }
 
       await fs.writeFile(
@@ -47,3 +37,17 @@ async function download() {
 }
 
 download()
+
+function sanitize(input) {
+  return sanitizeHtml(input, {
+    allowedTags: ['b', 'strong', 'a', 'code'],
+    allowedAttributes: {
+      a: ['href', 'class']
+    },
+    textFilter(text) {
+      return text
+        .replace(/\{\{/, '&#123;&#123;')
+        .replace(/\}\}/, '&#125;&#125;')
+    }
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,17 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@brainly/onesky-utils": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@brainly/onesky-utils/-/onesky-utils-1.4.0.tgz",
+      "integrity": "sha512-hDbDdTBVFHHwjt5odydiRWkzU0jHnc+1ftbxdPT79YmNSkcsrs37Sd9VQVs/n92aagIGKk2Ga0dl13vIymwGug==",
+      "dev": true,
+      "requires": {
+        "md5": "^2.0.0",
+        "request": "^2.88.0",
+        "request-promise": "^4.2.2"
+      }
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -204,18 +215,19 @@
       "dev": true
     },
     "asn1": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-      "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
-      "optional": true
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
     },
     "assert-plus": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-      "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
-      "dev": true,
-      "optional": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
     },
     "assertion-error": {
       "version": "1.0.0",
@@ -229,19 +241,23 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
-    "async": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-      "dev": true,
-      "optional": true
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "aws-sign2": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-      "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
-      "dev": true,
-      "optional": true
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
+      "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -249,10 +265,25 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
     "binary-extensions": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+      "dev": true
+    },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true
     },
     "boolify": {
@@ -260,16 +291,6 @@
       "resolved": "https://registry.npmjs.org/boolify/-/boolify-1.0.1.tgz",
       "integrity": "sha1-tcCeF8rNET0Rt7s+04TMASmU2Gs=",
       "dev": true
-    },
-    "boom": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
-      "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "hoek": "0.9.x"
-      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -319,6 +340,12 @@
         "quick-lru": "^4.0.1"
       }
     },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
+    },
     "chai": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/chai/-/chai-1.8.1.tgz",
@@ -344,6 +371,12 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
       "dev": true
     },
     "chokidar": {
@@ -444,13 +477,12 @@
       "dev": true
     },
     "combined-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-      "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
-      "optional": true,
       "requires": {
-        "delayed-stream": "0.0.5"
+        "delayed-stream": "~1.0.0"
       }
     },
     "common-tags": {
@@ -486,6 +518,12 @@
       "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
       "dev": true
     },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -507,22 +545,20 @@
         }
       }
     },
-    "cryptiles": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
-      "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "boom": "0.4.x"
-      }
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+      "dev": true
     },
-    "ctype": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-      "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
-      "optional": true
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "debug": {
       "version": "4.1.1",
@@ -572,11 +608,10 @@
       }
     },
     "delayed-stream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-      "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
-      "dev": true,
-      "optional": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "depd": {
       "version": "2.0.0",
@@ -638,6 +673,16 @@
         "dom-serializer": "^0.2.1",
         "domelementtype": "^2.0.1",
         "domhandler": "^3.0.0"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "emoji-regex": {
@@ -1095,6 +1140,12 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
     "external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -1105,6 +1156,12 @@
         "iconv-lite": "^0.4.24",
         "tmp": "^0.0.33"
       }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "3.1.1",
@@ -1227,21 +1284,20 @@
       "dev": true
     },
     "forever-agent": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
-      "integrity": "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA=",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
     "form-data": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
-      "integrity": "sha1-kavXiKupcCsaq/qLwBAxoqyeOxI=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
-      "optional": true,
       "requires": {
-        "async": "~0.9.0",
-        "combined-stream": "~0.0.4",
-        "mime": "~1.2.11"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
       }
     },
     "fs.realpath": {
@@ -1281,6 +1337,15 @@
       "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
       "dev": true
     },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -1318,6 +1383,22 @@
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
+      }
     },
     "has": {
       "version": "1.0.3",
@@ -1357,31 +1438,11 @@
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "dev": true
     },
-    "hawk": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
-      "integrity": "sha1-h81JH5tG5OKurKM1QWdmiF0tHtk=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "boom": "0.4.x",
-        "cryptiles": "0.2.x",
-        "hoek": "0.9.x",
-        "sntp": "0.2.x"
-      }
-    },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
-    },
-    "hoek": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
-      "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
-      "dev": true,
-      "optional": true
     },
     "hosted-git-info": {
       "version": "2.8.8",
@@ -1402,15 +1463,14 @@
       }
     },
     "http-signature": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-      "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
-      "optional": true,
       "requires": {
-        "asn1": "0.1.11",
-        "assert-plus": "^0.1.5",
-        "ctype": "0.5.3"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "i18next": {
@@ -1653,6 +1713,12 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -1663,6 +1729,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
     "js-tokens": {
@@ -1680,6 +1752,18 @@
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -1703,6 +1787,18 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.2.0.tgz",
       "integrity": "sha1-ttcDXHDEVw+IPH7cdZ3jrgPbM0M="
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
     },
     "keygrip": {
       "version": "1.1.0",
@@ -1867,6 +1963,25 @@
       "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
       "dev": true
     },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "dev": true,
+      "requires": {
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
+        }
+      }
+    },
     "messageformat": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-2.3.0.tgz",
@@ -1890,18 +2005,20 @@
       "integrity": "sha512-7dWuifeyldz7vhEuL96Kwq1fhZXBW+TUfbnHN4UCrCxoXQTYjHnR78eI66Gk9LaLLsAvzPNVJBaa66DRfFNaiA==",
       "dev": true
     },
-    "mime": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-      "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA=",
-      "dev": true,
-      "optional": true
+    "mime-db": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+      "dev": true
     },
     "mime-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
-      "integrity": "sha1-mVrhOSq4r/y/yyZB3QVOlDwNXc4=",
-      "dev": true
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.44.0"
+      }
     },
     "mimic-fn": {
       "version": "2.1.0",
@@ -2082,12 +2199,6 @@
         }
       }
     },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
-      "dev": true
-    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -2115,11 +2226,10 @@
       "dev": true
     },
     "oauth-sign": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz",
-      "integrity": "sha1-y1QPk7srIqfVlBaRoojWDo6pOG4=",
-      "dev": true,
-      "optional": true
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
     },
     "object-inspect": {
       "version": "1.7.0",
@@ -2174,24 +2284,6 @@
       "dev": true,
       "requires": {
         "wrappy": "1"
-      }
-    },
-    "onesky": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/onesky/-/onesky-0.1.6.tgz",
-      "integrity": "sha1-fw1oy4DN/51ETHzVURZdgow0zaw=",
-      "dev": true,
-      "requires": {
-        "request": "~2.40.0",
-        "underscore": "~1.6.0"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
-          "dev": true
-        }
       }
     },
     "onetime": {
@@ -2303,6 +2395,12 @@
       "requires": {
         "pify": "^2.0.0"
       }
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
     "picomatch": {
       "version": "2.2.1",
@@ -3005,8 +3103,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "punycode": {
       "version": "2.1.1",
@@ -3015,9 +3112,9 @@
       "dev": true
     },
     "qs": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-1.0.2.tgz",
-      "integrity": "sha1-UKk+K1r2aRwxvOpdrnjubqGQN2g=",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
     "quick-lru": {
@@ -3069,24 +3166,60 @@
       "dev": true
     },
     "request": {
-      "version": "2.40.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.40.0.tgz",
-      "integrity": "sha1-TdZw9pbx5uhC5mtLXoOTAaub62c=",
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "dev": true,
       "requires": {
-        "aws-sign2": "~0.5.0",
-        "forever-agent": "~0.5.0",
-        "form-data": "~0.1.0",
-        "hawk": "1.1.1",
-        "http-signature": "~0.10.0",
-        "json-stringify-safe": "~5.0.0",
-        "mime-types": "~1.0.1",
-        "node-uuid": "~1.4.0",
-        "oauth-sign": "~0.3.0",
-        "qs": "~1.0.0",
-        "stringstream": "~0.0.4",
-        "tough-cookie": ">=0.12.0",
-        "tunnel-agent": "~0.4.0"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      }
+    },
+    "request-promise": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.6.tgz",
+      "integrity": "sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.5.0",
+        "request-promise-core": "1.1.4",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.19"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.19",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+          "dev": true
+        }
       }
     },
     "require-directory": {
@@ -3149,6 +3282,12 @@
       "requires": {
         "tslib": "^1.9.0"
       }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -3220,16 +3359,6 @@
         }
       }
     },
-    "sntp": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
-      "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "hoek": "0.9.x"
-      }
-    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -3280,6 +3409,29 @@
       "integrity": "sha512-00kZI87TdRKwt+P8jj8UZxbfp7mK2ufxcIMWvhAOZNJTRROimpHeruWrGvCZneiuVDLqdyHefVp748ECTnyUBQ==",
       "dev": true
     },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
+    },
     "string-width": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
@@ -3321,13 +3473,6 @@
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"
       }
-    },
-    "stringstream": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
-      "dev": true,
-      "optional": true
     },
     "strip-bom": {
       "version": "3.0.0",
@@ -3433,15 +3578,13 @@
       }
     },
     "tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "dev": true,
-      "optional": true,
       "requires": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.1.2"
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
       }
     },
     "tslib": {
@@ -3456,11 +3599,19 @@
       "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
     },
     "tunnel-agent": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
-      "optional": true
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -3483,13 +3634,6 @@
       "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
-    "universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "optional": true
-    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -3498,6 +3642,12 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.1.0",
@@ -3513,6 +3663,17 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
       }
     },
     "vue-eslint-parser": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "i18next": "^1.10.6"
   },
   "devDependencies": {
+    "@brainly/onesky-utils": "^1.4.0",
     "chai": "~1.8.1",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.0",
@@ -29,7 +30,6 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
     "mocha": "^7.1.0",
-    "onesky": "^0.1.6",
     "prettier-eslint-cli": "^5.0.0",
     "sanitize-html": "^1.27.1"
   }


### PR DESCRIPTION
### Description

Replaces the deprecated [`onesky` package](https://www.npmjs.com/package/onesky) with the [`@brainly/onesky-utils` package](https://www.npmjs.com/package/@brainly/onesky-utils).

#### Related Issues / PRs

Closes https://github.com/overleaf/issues/issues/3329

### Review

As noted in the comment, our OneSky set-up appears to not really be the recommended workflow. [This documentation](https://support.oneskyapp.com/hc/en-us/articles/221630548-How-to-integrate-OneSky-APIs-into-your-translation-workflow-process) seems to imply that we should be uploading files containing new translation keys/default translations. These are then used to generate files stored with OneSky.

We do have a single file stored on OneSky, but it is quite out-of-date, leading me to think that it is not really used. However I am unsure if it can be removed, as we have to provide the filename to be able to fetch all of the other translations.

I also took the opportunity to switch to async/await, as the new package uses promises.

#### Manual Testing Performed

- [x] Ran it, no diff in `locale` dir

### Who Needs to Know?

@jdleesmiller fyi on the notes about the OneSky setup.