### PR TITLE
Upgrade i18next to latest

### DIFF
--- a/app/js/translations.js
+++ b/app/js/translations.js
@@ -68,11 +68,15 @@ module.exports = {
     const expressMiddleware = function(req, res, next) {
       middleware.handle(i18n)(req, res, (...args) => {
         // Decorate req.i18n with translate function alias for backwards
-        // compatibility
+        // compatibility usage in requests
         req.i18n.translate = req.i18n.t
         next(...args)
       })
     }
+
+    // Decorate i18n with translate function alias for backwards compatibility
+    // directly
+    i18n.translate = i18n.t
 
     return {
       expressMiddleware,

--- a/app/js/translations.js
+++ b/app/js/translations.js
@@ -1,5 +1,6 @@
 const i18n = require('i18next')
 const fsBackend = require('i18next-fs-backend')
+const middleware = require('i18next-http-middleware')
 const path = require('path')
 
 module.exports = {
@@ -48,7 +49,7 @@ module.exports = {
       next()
     }
 
-    const expressMiddleware = i18n.handle
+    const expressMiddleware = middleware.handle(i18n)
     return {
       expressMiddleware,
       setLangBasedOnDomainMiddleware,

--- a/app/js/translations.js
+++ b/app/js/translations.js
@@ -35,7 +35,7 @@ module.exports = {
 
       // Unless setLng query param is set, use subdomain lang
       if (!req.originalUrl.includes('setLng') && lang != null) {
-        req.i18n.setLng(lang)
+        req.i18n.changeLanguage(lang)
       }
 
       // If the set language (req.lng) is different from the language

--- a/app/js/translations.js
+++ b/app/js/translations.js
@@ -13,8 +13,10 @@ module.exports = {
         loadPath: path.join(__dirname, '../../locales/{{lng}}.json')
       },
 
+      // Load translation files synchronously: https://www.i18next.com/overview/configuration-options#initimmediate
       initImmediate: false,
 
+      // We use the i18next v1 JSON format: https://www.i18next.com/misc/json-format#i-18-next-json-v1
       compatibilityJSON: 'v1',
 
       preload: availableLngs,

--- a/app/js/translations.js
+++ b/app/js/translations.js
@@ -22,6 +22,8 @@ module.exports = {
       fallbackLng: options.defaultLng || 'en'
     })
 
+    const langDetector = new middleware.LanguageDetector(i18n.services)
+
     function setLangBasedOnDomainMiddleware(req, res, next) {
       // Determine language from subdomain
       const { host } = req.headers
@@ -38,12 +40,12 @@ module.exports = {
         req.i18n.changeLanguage(lang)
       }
 
-      // If the set language (req.lng) is different from the language
-      // automatically determined by the i18next middleware (req.language), then
-      // set flag which will show a banner offering to switch to the appropriate
-      // language
-      if (req.language !== req.lng) {
-        req.showUserOtherLng = req.language
+      // If the set language is different from the language detection (based on
+      // the Accept-Language header), then set flag which will show a banner
+      // offering to switch to the appropriate library
+      const detectedLanguage = langDetector.detect(req, res)
+      if (req.language !== detectedLanguage) {
+        req.showUserOtherLng = detectedLanguage
       }
 
       next()

--- a/app/js/translations.js
+++ b/app/js/translations.js
@@ -25,7 +25,10 @@ module.exports = {
         // Disable escaping of interpolated values for backwards compatibility.
         // We escape the value after it's translated in web, so there's no
         // security risk
-        escapeValue: false
+        escapeValue: false,
+        // Disable nesting in interpolated values, preventing user input
+        // injection via another nested value
+        skipOnVariables: true
       },
 
       preload: availableLngs,

--- a/app/js/translations.js
+++ b/app/js/translations.js
@@ -1,4 +1,5 @@
 const i18n = require('i18next')
+const fsBackend = require('i18next-fs-backend')
 const path = require('path')
 
 module.exports = {
@@ -6,20 +7,18 @@ module.exports = {
     const subdomainLang = options.subdomainLang || {}
     const availableLngs = Object.values(subdomainLang).map(c => c.lngCode)
 
-    i18n.init({
-      resGetPath: path.resolve(__dirname, '../../', 'locales/__lng__.json'),
-      saveMissing: true,
-      resSetPath: path.resolve(
-        __dirname,
-        '../../',
-        'locales/missing-__lng__.json'
-      ),
-      sendMissingTo: 'fallback',
-      fallbackLng: options.defaultLng || 'en',
-      detectLngFromHeaders: true,
-      useCookie: false,
+    i18n.use(fsBackend).init({
+      backend: {
+        loadPath: path.join(__dirname, '../../locales/{{lng}}.json')
+      },
+
+      initImmediate: false,
+
+      compatibilityJSON: 'v1',
+
       preload: availableLngs,
-      supportedLngs: availableLngs
+      supportedLngs: availableLngs,
+      fallbackLng: options.defaultLng || 'en'
     })
 
     function setLangBasedOnDomainMiddleware(req, res, next) {

--- a/app/js/translations.js
+++ b/app/js/translations.js
@@ -10,14 +10,18 @@ module.exports = {
 
     i18n.use(fsBackend).init({
       backend: {
-        loadPath: path.join(__dirname, '../../locales/{{lng}}.json')
+        loadPath: path.join(__dirname, '../../locales/__lng__.json')
       },
 
       // Load translation files synchronously: https://www.i18next.com/overview/configuration-options#initimmediate
       initImmediate: false,
 
-      // We use the i18next v1 JSON format: https://www.i18next.com/misc/json-format#i-18-next-json-v1
-      compatibilityJSON: 'v1',
+      // We use the legacy v1 JSON format, so configure interpolator to use
+      // underscores instead of curly braces
+      interpolation: {
+        prefix: '__',
+        suffix: '__'
+      },
 
       preload: availableLngs,
       supportedLngs: availableLngs,

--- a/app/js/translations.js
+++ b/app/js/translations.js
@@ -21,7 +21,11 @@ module.exports = {
       interpolation: {
         prefix: '__',
         suffix: '__',
-        unescapeSuffix: 'HTML'
+        unescapeSuffix: 'HTML',
+        // Disable escaping of interpolated values for backwards compatibility.
+        // We escape the value after it's translated in web, so there's no
+        // security risk
+        escapeValue: false
       },
 
       preload: availableLngs,

--- a/app/js/translations.js
+++ b/app/js/translations.js
@@ -20,7 +20,8 @@ module.exports = {
       // underscores instead of curly braces
       interpolation: {
         prefix: '__',
-        suffix: '__'
+        suffix: '__',
+        unescapeSuffix: 'HTML'
       },
 
       preload: availableLngs,

--- a/app/js/translations.js
+++ b/app/js/translations.js
@@ -57,7 +57,15 @@ module.exports = {
       next()
     }
 
-    const expressMiddleware = middleware.handle(i18n)
+    const expressMiddleware = function(req, res, next) {
+      middleware.handle(i18n)(req, res, (...args) => {
+        // Decorate req.i18n with translate function alias for backwards
+        // compatibility
+        req.i18n.translate = req.i18n.t
+        next(...args)
+      })
+    }
+
     return {
       expressMiddleware,
       setLangBasedOnDomainMiddleware,

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,14 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@babel/runtime": {
+      "version": "7.10.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.5.tgz",
+      "integrity": "sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==",
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@brainly/onesky-utils": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@brainly/onesky-utils/-/onesky-utils-1.4.0.tgz",
@@ -503,15 +511,6 @@
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
-    "cookies": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.8.0.tgz",
-      "integrity": "sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==",
-      "requires": {
-        "depd": "~2.0.0",
-        "keygrip": "~1.1.0"
-      }
-    },
     "core-js": {
       "version": "3.6.4",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
@@ -612,11 +611,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
-    },
-    "depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
     },
     "diff": {
       "version": "3.5.0",
@@ -1474,19 +1468,12 @@
       }
     },
     "i18next": {
-      "version": "1.10.6",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-1.10.6.tgz",
-      "integrity": "sha1-/d2LSRUCxIlnpiljvHIv+JfN3qA=",
+      "version": "19.6.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.6.3.tgz",
+      "integrity": "sha512-eYr98kw/C5z6kY21ti745p4IvbOJwY8F2T9tf/Lvy5lFnYRqE45+bppSgMPmcZZqYNT+xO0N0x6rexVR2wtZZQ==",
       "requires": {
-        "cookies": ">= 0.2.2",
-        "i18next-client": "1.10.3",
-        "json5": "^0.2.0"
+        "@babel/runtime": "^7.10.1"
       }
-    },
-    "i18next-client": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/i18next-client/-/i18next-client-1.10.3.tgz",
-      "integrity": "sha1-dtA1NVftkNHnqHdU1QBNP3gB/ek="
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -1783,11 +1770,6 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
-    "json5": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.2.0.tgz",
-      "integrity": "sha1-ttcDXHDEVw+IPH7cdZ3jrgPbM0M="
-    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -1798,14 +1780,6 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
-      }
-    },
-    "keygrip": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
-      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
-      "requires": {
-        "tsscmp": "1.0.6"
       }
     },
     "levn": {
@@ -3159,6 +3133,11 @@
         "picomatch": "^2.0.4"
       }
     },
+    "regenerator-runtime": {
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+    },
     "regexpp": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
@@ -3592,11 +3571,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
       "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
       "dev": true
-    },
-    "tsscmp": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
-      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1480,6 +1480,11 @@
       "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-1.0.7.tgz",
       "integrity": "sha512-aAZ3rvshe1Zbl6JSCWrWWqbZS5JpmVNG+84YqLcgdYcm9uAxzw4xWxnA/a3044Nm2PKXE62CT+pIZjk7OEYtTw=="
     },
+    "i18next-http-middleware": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/i18next-http-middleware/-/i18next-http-middleware-3.0.2.tgz",
+      "integrity": "sha512-h6n6+4k6EbYjtACPSslEkpf3Qf404QpENGb87auMSA77QBna9dUBWNAzG3jmqzK9cV4p8ZjsQTrwMzu+xyYaXw=="
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1475,6 +1475,11 @@
         "@babel/runtime": "^7.10.1"
       }
     },
+    "i18next-fs-backend": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-1.0.7.tgz",
+      "integrity": "sha512-aAZ3rvshe1Zbl6JSCWrWWqbZS5JpmVNG+84YqLcgdYcm9uAxzw4xWxnA/a3044Nm2PKXE62CT+pIZjk7OEYtTw=="
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "i18next": "^19.6.3",
-    "i18next-fs-backend": "^1.0.7"
+    "i18next-fs-backend": "^1.0.7",
+    "i18next-http-middleware": "^3.0.2"
   },
   "devDependencies": {
     "@brainly/onesky-utils": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "mocha $@ test/unit/js"
   },
   "dependencies": {
-    "i18next": "^1.10.6"
+    "i18next": "^19.6.3"
   },
   "devDependencies": {
     "@brainly/onesky-utils": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "mocha $@ test/unit/js"
   },
   "dependencies": {
-    "i18next": "^19.6.3"
+    "i18next": "^19.6.3",
+    "i18next-fs-backend": "^1.0.7"
   },
   "devDependencies": {
     "@brainly/onesky-utils": "^1.4.0",

--- a/test/unit/js/translations-tests.js
+++ b/test/unit/js/translations-tests.js
@@ -24,6 +24,25 @@ describe('translations', function() {
     }
   })
 
+  describe('query string detection', function() {
+    it('sets the language to french if the setLng query string is fr', function(done) {
+      this.req.originalUrl = 'www.sharelatex.com/login?setLng=fr'
+      this.req.url = 'www.sharelatex.com/login'
+      this.req.query = { setLng: 'fr' }
+      this.req.headers.host = 'www.sharelatex.com'
+      this.translations.expressMiddleware(this.req, this.res, () => {
+        this.translations.setLangBasedOnDomainMiddleware(
+          this.req,
+          this.res,
+          () => {
+            expect(this.req.lng).to.equal('fr')
+            done()
+          }
+        )
+      })
+    })
+  })
+
   describe('setLangBasedOnDomainMiddleware', function() {
     it('should set the lang to french if the domain is fr', function(done) {
       this.req.url = 'fr.sharelatex.com/login'
@@ -43,6 +62,7 @@ describe('translations', function() {
     it('ignores domain if setLng query param is set', function(done) {
       this.req.originalUrl = 'fr.sharelatex.com/login?setLng=en'
       this.req.url = 'fr.sharelatex.com/login'
+      this.req.query = { setLng: 'en' }
       this.req.headers.host = 'fr.sharelatex.com'
       this.translations.expressMiddleware(this.req, this.res, () => {
         this.translations.setLangBasedOnDomainMiddleware(

--- a/test/unit/js/translations-tests.js
+++ b/test/unit/js/translations-tests.js
@@ -109,5 +109,52 @@ describe('translations', function() {
         })
       })
     })
+
+    describe('interpolation', function() {
+      beforeEach(function(done) {
+        this.req.url = 'www.sharelatex.com/login'
+        this.req.headers.host = 'www.sharelatex.com'
+        this.translations.expressMiddleware(this.req, this.res, () => {
+          this.translations.setLangBasedOnDomainMiddleware(
+            this.req,
+            this.res,
+            done
+          )
+        })
+      })
+
+      it('works', function() {
+        expect(
+          this.req.i18n.t('please_confirm_email', {
+            emailAddress: 'foo@example.com'
+          })
+        ).to.equal(
+          'Please confirm your email foo@example.com by clicking on the link in the confirmation email '
+        )
+      })
+
+      it('handles dashes after interpolation', function() {
+        // This translation string has a problematic interpolation followed by a
+        // dash: `__len__-day`
+        expect(
+          this.req.i18n.t('faq_how_does_free_trial_works_answer', {
+            appName: 'Overleaf',
+            len: '5'
+          })
+        ).to.equal(
+          'You get full access to your chosen Overleaf plan during your 5-day free trial. There is no obligation to continue beyond the trial. Your card will be charged at the end of your 5 day trial unless you cancel before then. You can cancel via your subscription settings.'
+        )
+      })
+
+      it('disables escaping', function() {
+        expect(
+          this.req.i18n.translate('admin_user_created_message', {
+            link: 'http://google.com'
+          })
+        ).to.equal(
+          'Created admin user, <a href="http://google.com">Log in here</a> to continue'
+        )
+      })
+    })
   })
 })

--- a/test/unit/js/translations-tests.js
+++ b/test/unit/js/translations-tests.js
@@ -24,6 +24,61 @@ describe('translations', function() {
     }
   })
 
+  describe('translate', function() {
+    beforeEach(function(done) {
+      this.req.url = 'www.sharelatex.com/login'
+      this.translations.expressMiddleware(this.req, this.res, done)
+    })
+
+    it('works', function() {
+      expect(this.req.i18n.t('give_feedback')).to.equal('Give feedback')
+    })
+
+    it('has translate alias', function() {
+      expect(this.req.i18n.translate('give_feedback')).to.equal('Give feedback')
+    })
+  })
+
+  describe('interpolation', function() {
+    beforeEach(function(done) {
+      this.req.url = 'www.sharelatex.com/login'
+      this.translations.expressMiddleware(this.req, this.res, done)
+    })
+
+    it('works', function() {
+      expect(
+        this.req.i18n.t('please_confirm_email', {
+          emailAddress: 'foo@example.com'
+        })
+      ).to.equal(
+        'Please confirm your email foo@example.com by clicking on the link in the confirmation email '
+      )
+    })
+
+    it('handles dashes after interpolation', function() {
+      // This translation string has a problematic interpolation followed by a
+      // dash: `__len__-day`
+      expect(
+        this.req.i18n.t('faq_how_does_free_trial_works_answer', {
+          appName: 'Overleaf',
+          len: '5'
+        })
+      ).to.equal(
+        'You get full access to your chosen Overleaf plan during your 5-day free trial. There is no obligation to continue beyond the trial. Your card will be charged at the end of your 5 day trial unless you cancel before then. You can cancel via your subscription settings.'
+      )
+    })
+
+    it('disables escaping', function() {
+      expect(
+        this.req.i18n.t('admin_user_created_message', {
+          link: 'http://google.com'
+        })
+      ).to.equal(
+        'Created admin user, <a href="http://google.com">Log in here</a> to continue'
+      )
+    })
+  })
+
   describe('query string detection', function() {
     it('sets the language to french if the setLng query string is fr', function(done) {
       this.req.originalUrl = 'www.sharelatex.com/login?setLng=fr'
@@ -77,7 +132,7 @@ describe('translations', function() {
     })
 
     describe('showUserOtherLng', function() {
-      it('should set it to true if the language based on headers is different to lng', function(done) {
+      it('should set showUserOtherLng=true if the detected lang is different to subdomain lang', function(done) {
         this.req.headers['accept-language'] = 'da, en-gb;q=0.8, en;q=0.7'
         this.req.url = 'fr.sharelatex.com/login'
         this.req.headers.host = 'fr.sharelatex.com'
@@ -93,7 +148,7 @@ describe('translations', function() {
         })
       })
 
-      it('should not set prop', function(done) {
+      it('should not set showUserOtherLng if the detected lang is the same as subdomain lang', function(done) {
         this.req.headers['accept-language'] = 'da, en-gb;q=0.8, en;q=0.7'
         this.req.url = 'da.sharelatex.com/login'
         this.req.headers.host = 'da.sharelatex.com'
@@ -107,53 +162,6 @@ describe('translations', function() {
             }
           )
         })
-      })
-    })
-
-    describe('interpolation', function() {
-      beforeEach(function(done) {
-        this.req.url = 'www.sharelatex.com/login'
-        this.req.headers.host = 'www.sharelatex.com'
-        this.translations.expressMiddleware(this.req, this.res, () => {
-          this.translations.setLangBasedOnDomainMiddleware(
-            this.req,
-            this.res,
-            done
-          )
-        })
-      })
-
-      it('works', function() {
-        expect(
-          this.req.i18n.t('please_confirm_email', {
-            emailAddress: 'foo@example.com'
-          })
-        ).to.equal(
-          'Please confirm your email foo@example.com by clicking on the link in the confirmation email '
-        )
-      })
-
-      it('handles dashes after interpolation', function() {
-        // This translation string has a problematic interpolation followed by a
-        // dash: `__len__-day`
-        expect(
-          this.req.i18n.t('faq_how_does_free_trial_works_answer', {
-            appName: 'Overleaf',
-            len: '5'
-          })
-        ).to.equal(
-          'You get full access to your chosen Overleaf plan during your 5-day free trial. There is no obligation to continue beyond the trial. Your card will be charged at the end of your 5 day trial unless you cancel before then. You can cancel via your subscription settings.'
-        )
-      })
-
-      it('disables escaping', function() {
-        expect(
-          this.req.i18n.translate('admin_user_created_message', {
-            link: 'http://google.com'
-          })
-        ).to.equal(
-          'Created admin user, <a href="http://google.com">Log in here</a> to continue'
-        )
       })
     })
   })

--- a/test/unit/js/translations-tests.js
+++ b/test/unit/js/translations-tests.js
@@ -25,7 +25,7 @@ describe('translations', function() {
     it('should set the lang to french if the domain is fr', function(done) {
       this.req.url = 'fr.sharelatex.com/login'
       this.req.headers.host = 'fr.sharelatex.com'
-      this.translations.expressMiddleware(this.req, this.req, () => {
+      this.translations.expressMiddleware(this.req, this.res, () => {
         this.translations.setLangBasedOnDomainMiddleware(
           this.req,
           this.res,
@@ -41,7 +41,7 @@ describe('translations', function() {
       this.req.originalUrl = 'fr.sharelatex.com/login?setLng=en'
       this.req.url = 'fr.sharelatex.com/login'
       this.req.headers.host = 'fr.sharelatex.com'
-      this.translations.expressMiddleware(this.req, this.req, () => {
+      this.translations.expressMiddleware(this.req, this.res, () => {
         this.translations.setLangBasedOnDomainMiddleware(
           this.req,
           this.res,
@@ -58,7 +58,7 @@ describe('translations', function() {
         this.req.headers['accept-language'] = 'da, en-gb;q=0.8, en;q=0.7'
         this.req.url = 'fr.sharelatex.com/login'
         this.req.headers.host = 'fr.sharelatex.com'
-        this.translations.expressMiddleware(this.req, this.req, () => {
+        this.translations.expressMiddleware(this.req, this.res, () => {
           this.translations.setLangBasedOnDomainMiddleware(
             this.req,
             this.res,
@@ -74,7 +74,7 @@ describe('translations', function() {
         this.req.headers['accept-language'] = 'da, en-gb;q=0.8, en;q=0.7'
         this.req.url = 'da.sharelatex.com/login'
         this.req.headers.host = 'da.sharelatex.com'
-        this.translations.expressMiddleware(this.req, this.req, () => {
+        this.translations.expressMiddleware(this.req, this.res, () => {
           this.translations.setLangBasedOnDomainMiddleware(
             this.req,
             this.res,

--- a/test/unit/js/translations-tests.js
+++ b/test/unit/js/translations-tests.js
@@ -18,7 +18,10 @@ describe('translations', function() {
         'accept-language': ''
       }
     }
-    this.res = {}
+    this.res = {
+      getHeader: () => {},
+      setHeader: () => {}
+    }
   })
 
   describe('setLangBasedOnDomainMiddleware', function() {


### PR DESCRIPTION
### Description

Upgrades i18next to v19, and change the config/set up to match the new API.

### Related Issues / PRs

Closes https://github.com/overleaf/issues/issues/3276

### Review

Probably best reviewed commit-by-commit.

I don't believe there are any changes needed on the web side. I've tried to keep this backwards compatible.

### Manual Testing

Installed the branch to a local version of web and checked

- [x] English translations work
- [x] French translations work
- [x] Interpolation works
  - [x] Basic
  - [x] With multiple interpolations (e.g. `Hello __foo__-world __bar__`)
  - [x] With escaping disabled
- [x] `showUserOtherLng` flag works